### PR TITLE
Post-release merge into 'develop'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<name>Smarter Balanced Shared Code</name>
 	<artifactId>sb11-shared-code</artifactId>
-	<version>0.0.6-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -13,15 +13,15 @@
 	</parent>
 
     <scm>
-        <connection>scm:git:https://github.com/SmarterApp/SharedCode</connection>
-        <developerConnection>scm:git:https://github.com/SmarterApp/SharedCode</developerConnection>
-        <url>https://github.com/SmarterApp/SharedCode</url>
+        <connection>scm:git:https://github.com/SmarterApp/SS_SharedCode.git</connection>
+        <developerConnection>scm:git:git://github.com/SmarterApp/SS_SharedCode.git</developerConnection>
+        <url>https://github.com/SmarterApp/SS_SharedCode</url>
+		<tag>HEAD</tag>
     </scm>
 
     <prerequisites>
         <maven>3.0.0</maven>
     </prerequisites>
-
 
 	<build>
 		<plugins>
@@ -338,13 +338,13 @@
 		</dependency>
 		
 	</dependencies>
-	
-	<!--distributionManagement>
-       <repository>
-            <id>central</id>
-            <name>libs-releases</name>
-            <url>http://airdev.artifactoryonline.com/airdev/libs-releases-local</url>
-        </repository>
-    </distributionManagement-->
+
+	<distributionManagement>
+		<repository>
+			<id>central</id>
+			<name>airdev-releases</name>
+			<url>https://airdev.jfrog.io/airdev/libs-releases-local</url>
+		</repository>
+	</distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<name>Smarter Balanced Shared Code</name>
 	<artifactId>sb11-shared-code</artifactId>
-	<version>3.0.0</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -16,7 +16,7 @@
         <connection>scm:git:https://github.com/SmarterApp/SS_SharedCode.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/SS_SharedCode.git</developerConnection>
         <url>https://github.com/SmarterApp/SS_SharedCode</url>
-		<tag>3.0.0</tag>
+		<tag>HEAD</tag>
     </scm>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<name>Smarter Balanced Shared Code</name>
 	<artifactId>sb11-shared-code</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -16,7 +16,7 @@
         <connection>scm:git:https://github.com/SmarterApp/SS_SharedCode.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/SS_SharedCode.git</developerConnection>
         <url>https://github.com/SmarterApp/SS_SharedCode</url>
-		<tag>HEAD</tag>
+		<tag>3.0.0</tag>
     </scm>
 
     <prerequisites>


### PR DESCRIPTION
All consumers of this project have been changed to depend upon the released version.  We are now free to merge the post-release snapshot version back into 'develop'