### PR TITLE
Log exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,19 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>2.5.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>uk.co.jemos.podam</groupId>
 			<artifactId>podam</artifactId>
 			<version>${podam.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,7 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>2.5.0</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/opentestsystem/delivery/logging/EventInfo.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventInfo.java
@@ -1,70 +1,84 @@
 package org.opentestsystem.delivery.logging;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Optional;
 import org.opentestsystem.delivery.logging.EventLogger.EventData;
 
+import java.util.HashMap;
 import java.util.Map;
 
-@AutoValue
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
+
 /**
  * Event to be logged to central logging
  * Used to simplify the number of parameters sent to the logger
  */
-public abstract class EventInfo {
+public class EventInfo {
+  private String event;
+  private String checkpoint;
+  private String message;
+  private final Map<EventData, Object> data = new HashMap<>();
 
   /**
    * @return Name of the current event
    */
-  abstract String event();
+  public String event() {
+    return event;
+  }
+
+  void setEvent(final String event) {
+    this.event = event;
+  }
 
   /**
    * @return Moment in time of the event, such as the entry, exit or error
    */
-  abstract Optional<String> checkpoint();
+  public Optional<String> checkpoint() {
+    return Optional.fromNullable(checkpoint);
+  }
+
+  void setCheckpoint(final String checkpoint) {
+    this.checkpoint = checkpoint;
+  }
 
   /**
    * @return Optional message for the event
    */
-  abstract Optional<String> message();
+  public Optional<String> message() {
+    return Optional.fromNullable(message);
+  }
+
+  void setMessage(final String message) {
+    this.message = message;
+  }
 
   /**
    * @return Event data payload that is used to access the event from log files
    */
-  abstract Map<EventData, Object> data();
-
-  public static EventInfo create(String event, String checkpoint, String message, Map<EventData, Object> data) {
-    return builder()
-      .event(event)
-      .checkpoint(Optional.of(checkpoint))
-      .message(Optional.of(message))
-      .data(data)
-      .build();
+  public Map<EventData, Object> data() {
+    return data;
   }
 
-  public static EventInfo create(String event, String checkpoint, Map<EventData, Object> data) {
-    return builder()
-      .event(event)
-      .checkpoint(Optional.of(checkpoint))
-      .message(Optional.<String>absent())
-      .data(data)
-      .build();
+  void setData(final Map<EventData, Object> data) {
+    this.data.putAll(data);
   }
 
-  public static EventInfo create(String event, Map<EventData, Object> data) {
-    return builder()
-      .event(event)
-      .checkpoint(Optional.<String>absent())
-      .message(Optional.<String>absent())
-      .data(data)
-      .build();
+  /**
+   * Create a builder containing this EventInfo's values.
+   *
+   * @return A builder
+   */
+  public EventInfoBuilder toBuilder() {
+    return builder().copy(this);
   }
 
-  public static Builder builder() {
-    return new AutoValue_EventInfo.Builder();
+  /**
+   * Create a new empty builder.
+   *
+   * @return A builder
+   */
+  public static EventInfoBuilder builder() {
+    return new EventInfoBuilder();
   }
-
-  abstract Builder toBuilder();
 
   /**
    * Copy of this EventInfo with checkpoint changed
@@ -72,8 +86,8 @@ public abstract class EventInfo {
    * @param checkpoint new value of checkpoint
    * @return Copy of this EventInfo with a new checkpoint
    */
-  public EventInfo withCheckpoint(String checkpoint) {
-    return toBuilder().checkpoint(Optional.of(checkpoint)).build();
+  public EventInfo withCheckpoint(final String checkpoint) {
+    return toBuilder().checkpoint(checkpoint).build();
   }
 
   /**
@@ -82,20 +96,52 @@ public abstract class EventInfo {
    * @param message new value of message
    * @return Copy of this EventInfo with a new message
    */
-  public EventInfo withMessage(String message) {
-    return toBuilder().message(Optional.of(message)).build();
+  public EventInfo withMessage(final String message) {
+    return toBuilder().message(message).build();
   }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder event(String event);
+  public static class EventInfoBuilder {
+    private String event;
+    private String checkpoint;
+    private String message;
+    private final Map<EventData, Object> data = new HashMap<>();
 
-    public abstract Builder checkpoint(Optional<String> checkpoint);
+    public EventInfoBuilder event(final String event) {
+      this.event = trimToEmpty(event);
+      return this;
+    }
 
-    public abstract Builder message(Optional<String> message);
+    public EventInfoBuilder checkpoint(final String checkpoint) {
+      this.checkpoint = checkpoint;
+      return this;
+    }
 
-    public abstract Builder data(Map<EventData, Object> data);
+    public EventInfoBuilder message(final String message) {
+      this.message = message;
+      return this;
+    }
 
-    public abstract EventInfo build();
+    public EventInfoBuilder data(final Map<EventData, Object> data) {
+      this.data.clear();
+      this.data.putAll(data);
+      return this;
+    }
+
+    public EventInfoBuilder copy(final EventInfo eventInfo) {
+      event(eventInfo.event());
+      checkpoint(eventInfo.checkpoint().orNull());
+      message(eventInfo.message().orNull());
+      data(eventInfo.data());
+      return this;
+    }
+
+    public EventInfo build() {
+      final EventInfo eventInfo = new EventInfo();
+      eventInfo.setEvent(trimToEmpty(event));
+      eventInfo.setCheckpoint(checkpoint);
+      eventInfo.setMessage(message);
+      eventInfo.setData(data);
+      return eventInfo;
+    }
   }
 }

--- a/src/main/java/org/opentestsystem/delivery/logging/EventParser.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventParser.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpSession;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.opentestsystem.delivery.logging.EventLogger.BaseEventData.HTTP_REQUEST_PARAMETERS;
 import static org.opentestsystem.delivery.logging.EventLogger.BaseEventData.HTTP_SESSION_ID;
 
@@ -24,7 +25,7 @@ public class EventParser {
    * @return
    */
   public Optional<EventInfo> parsePreHandle(final HttpServletRequest request, final Object handler, final EventLogger logger) {
-    return Optional.of(EventInfo.create(request.getPathInfo(), getEventDataFields(request)));
+    return Optional.of(EventInfo.create(getPath(request), getEventDataFields(request)));
   }
 
   /**
@@ -35,7 +36,7 @@ public class EventParser {
    */
   public Optional<EventInfo> parsePostHandle(final HttpServletRequest request, final HttpServletResponse response, final Object
     handler, EventLogger logger) {
-    return Optional.of(EventInfo.create(request.getPathInfo(), getEventDataFields(request)));
+    return Optional.of(EventInfo.create(getPath(request), getEventDataFields(request)));
   }
 
   public static Map<EventLogger.EventData, Object> getEventDataFields(final HttpServletRequest request) {
@@ -48,6 +49,10 @@ public class EventParser {
     data.put(HTTP_REQUEST_PARAMETERS, request.getParameterMap());
 
     return data;
+  }
+
+  public static String getPath(final HttpServletRequest request) {
+    return trimToEmpty(request.getPathInfo());
   }
 }
 

--- a/src/main/java/org/opentestsystem/delivery/logging/EventParser.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventParser.java
@@ -8,7 +8,6 @@ import javax.servlet.http.HttpSession;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.opentestsystem.delivery.logging.EventLogger.BaseEventData.HTTP_REQUEST_PARAMETERS;
 import static org.opentestsystem.delivery.logging.EventLogger.BaseEventData.HTTP_SESSION_ID;
 
@@ -25,7 +24,7 @@ public class EventParser {
    * @return
    */
   public Optional<EventInfo> parsePreHandle(final HttpServletRequest request, final Object handler, final EventLogger logger) {
-    return Optional.of(EventInfo.create(getPath(request), getEventDataFields(request)));
+    return Optional.of(EventInfo.builder().event(request.getPathInfo()).data(getEventDataFields(request)).build());
   }
 
   /**
@@ -35,8 +34,8 @@ public class EventParser {
    * @return
    */
   public Optional<EventInfo> parsePostHandle(final HttpServletRequest request, final HttpServletResponse response, final Object
-    handler, EventLogger logger) {
-    return Optional.of(EventInfo.create(getPath(request), getEventDataFields(request)));
+    handler, final EventLogger logger) {
+    return Optional.of(EventInfo.builder().event(request.getPathInfo()).data(getEventDataFields(request)).build());
   }
 
   public static Map<EventLogger.EventData, Object> getEventDataFields(final HttpServletRequest request) {
@@ -49,10 +48,6 @@ public class EventParser {
     data.put(HTTP_REQUEST_PARAMETERS, request.getParameterMap());
 
     return data;
-  }
-
-  public static String getPath(final HttpServletRequest request) {
-    return trimToEmpty(request.getPathInfo());
   }
 }
 

--- a/src/main/java/org/opentestsystem/delivery/logging/EventParserFactory.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventParserFactory.java
@@ -3,14 +3,12 @@ package org.opentestsystem.delivery.logging;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
-import static org.opentestsystem.delivery.logging.EventParser.getPath;
-
 public abstract class EventParserFactory {
 
   /**
    * Implement this to provide the map of PATHINFO to EventParser Classes.
    *
-   * @return A map of PATHINFO to EventParser
+   * @return
    */
   protected abstract Map<String, Class<? extends EventParser>> getEventParserClassMap();
 
@@ -18,14 +16,14 @@ public abstract class EventParserFactory {
    * Returns an EventParser for the current request, as discovered via request.getPathInfo().
    * Used by logging interceptor to pull data out of the request and response for event logging.
    *
-   * @param request The request
-   * @return The associated EventParser
+   * @param request
+   * @return
    * @throws IllegalAccessException
    * @throws InstantiationException
    */
-  public EventParser get(final HttpServletRequest request) throws IllegalAccessException, InstantiationException {
-    if (getEventParserClassMap().containsKey(getPath(request))) {
-      return getEventParserClassMap().get(getPath(request)).newInstance();
+  public EventParser get(HttpServletRequest request) throws IllegalAccessException, InstantiationException {
+    if (getEventParserClassMap().containsKey(request.getPathInfo())) {
+      return getEventParserClassMap().get(request.getPathInfo()).newInstance();
     }
     if (getEventParserClassMap().containsKey("*")) {
       return getEventParserClassMap().get("*").newInstance();

--- a/src/main/java/org/opentestsystem/delivery/logging/EventParserFactory.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventParserFactory.java
@@ -3,12 +3,14 @@ package org.opentestsystem.delivery.logging;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
+import static org.opentestsystem.delivery.logging.EventParser.getPath;
+
 public abstract class EventParserFactory {
 
   /**
    * Implement this to provide the map of PATHINFO to EventParser Classes.
    *
-   * @return
+   * @return A map of PATHINFO to EventParser
    */
   protected abstract Map<String, Class<? extends EventParser>> getEventParserClassMap();
 
@@ -16,14 +18,14 @@ public abstract class EventParserFactory {
    * Returns an EventParser for the current request, as discovered via request.getPathInfo().
    * Used by logging interceptor to pull data out of the request and response for event logging.
    *
-   * @param request
-   * @return
+   * @param request The request
+   * @return The associated EventParser
    * @throws IllegalAccessException
    * @throws InstantiationException
    */
-  public EventParser get(HttpServletRequest request) throws IllegalAccessException, InstantiationException {
-    if (getEventParserClassMap().containsKey(request.getPathInfo())) {
-      return getEventParserClassMap().get(request.getPathInfo()).newInstance();
+  public EventParser get(final HttpServletRequest request) throws IllegalAccessException, InstantiationException {
+    if (getEventParserClassMap().containsKey(getPath(request))) {
+      return getEventParserClassMap().get(getPath(request)).newInstance();
     }
     if (getEventParserClassMap().containsKey("*")) {
       return getEventParserClassMap().get("*").newInstance();

--- a/src/main/java/org/opentestsystem/delivery/logging/LoggingExceptionHandler.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/LoggingExceptionHandler.java
@@ -1,13 +1,17 @@
 package org.opentestsystem.delivery.logging;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import javax.servlet.http.HttpServletRequest;
 
 import static org.opentestsystem.delivery.logging.LoggingInterceptor.EVENT_INFO;
 import static org.opentestsystem.delivery.logging.LoggingInterceptor.LOGGER_NAME;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @EnableWebMvc
 @ControllerAdvice
@@ -18,9 +22,23 @@ import static org.opentestsystem.delivery.logging.LoggingInterceptor.LOGGER_NAME
  * Called when unhandled exceptions in request mapping methods are thrown.
  */
 public class LoggingExceptionHandler {
+    private final static Logger LOG = LoggerFactory.getLogger(LoggingExceptionHandler.class);
+
     @ExceptionHandler
-    public static void handleException(HttpServletRequest request, Exception e) {
-        EventLogger logger = (EventLogger)request.getAttribute(LOGGER_NAME);
+    @ResponseStatus(INTERNAL_SERVER_ERROR)
+    public void handleExceptionFallback(final HttpServletRequest request, final Exception e) {
+        LOG.error("Problem handling request", e);
+        handleException(request, e);
+    }
+
+    /**
+     * Send the exception to the EventLogger.
+     *
+     * @param request The request
+     * @param e The exception
+     */
+    public static void handleException(final HttpServletRequest request, final Exception e) {
+        final EventLogger logger = (EventLogger)request.getAttribute(LOGGER_NAME);
         if (logger != null) {
             EventInfo eventInfo = (EventInfo)request.getAttribute(EVENT_INFO);
             logger.error(eventInfo.withCheckpoint(EventLogger.Checkpoint.ERROR.name()), e);

--- a/src/test/java/org/opentestsystem/delivery/logging/EventParserTest.java
+++ b/src/test/java/org/opentestsystem/delivery/logging/EventParserTest.java
@@ -1,0 +1,109 @@
+package org.opentestsystem.delivery.logging;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.delivery.logging.EventLogger.BaseEventData.HTTP_REQUEST_PARAMETERS;
+import static org.opentestsystem.delivery.logging.EventLogger.BaseEventData.HTTP_SESSION_ID;
+
+public class EventParserTest {
+    private final static Object HANDLER = new Object();
+
+    private HttpServletRequest request;
+    private EventLogger eventLogger;
+    private HttpServletResponse response;
+    private EventParser eventParser;
+
+    @Before
+    public void setup() {
+        request = mock(HttpServletRequest.class);
+        eventLogger = mock(EventLogger.class);
+        response = mock(HttpServletResponse.class);
+
+        eventParser = new EventParser();
+    }
+
+    @Test
+    public void itShouldAddRequestPathInfo() {
+        final String pathInfo = "/some/path";
+        when(request.getPathInfo()).thenReturn(pathInfo);
+
+        EventInfo info = eventParser.parsePreHandle(request, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.event()).isEqualTo(pathInfo);
+
+        info = eventParser.parsePostHandle(request, response, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.event()).isEqualTo(pathInfo);
+    }
+
+    @Test
+    public void itShouldHandleANullRequestPathInfo() {
+        when(request.getPathInfo()).thenReturn(null);
+
+        EventInfo info = eventParser.parsePreHandle(request, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.event()).isEmpty();
+
+        info = eventParser.parsePostHandle(request, response, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.event()).isEmpty();
+    }
+
+    @Test
+    public void itShouldOptionallyAppendSessionInfo() {
+        when(request.getSession(false)).thenReturn(null);
+
+        EventInfo info = eventParser.parsePreHandle(request, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.data()).doesNotContainKey(HTTP_SESSION_ID);
+
+        info = eventParser.parsePostHandle(request, response, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.data()).doesNotContainKey(HTTP_SESSION_ID);
+
+        final String sessionId = "sessionId";
+        final HttpSession session = mock(HttpSession.class);
+        when(session.getId()).thenReturn(sessionId);
+        when(request.getSession(false)).thenReturn(session);
+
+        info = eventParser.parsePreHandle(request, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.data()).containsEntry(HTTP_SESSION_ID, sessionId);
+
+        info = eventParser.parsePostHandle(request, response, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.data()).containsEntry(HTTP_SESSION_ID, sessionId);
+    }
+
+    @Test
+    public void itShouldAppendRequestParameters() {
+        final Map<String, String[]> parameterMap = ImmutableMap.of(
+            "key1", new String[]{"val1"},
+            "key2", new String[]{"val2a", "val2b"});
+        when(request.getParameterMap()).thenReturn(parameterMap);
+
+        EventInfo info = eventParser.parsePreHandle(request, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.data()).containsKey(HTTP_REQUEST_PARAMETERS);
+        Map<String, String[]> infoValues = (Map<String, String[]>)info.data().get(HTTP_REQUEST_PARAMETERS);
+        assertThat(infoValues).containsOnly(infoValues.entrySet().toArray(new Map.Entry[infoValues.entrySet().size()]));
+
+        info = eventParser.parsePostHandle(request, response, HANDLER, eventLogger).orNull();
+        assertThat(info).isNotNull();
+        assertThat(info.data()).containsKey(HTTP_REQUEST_PARAMETERS);
+        infoValues = (Map<String, String[]>)info.data().get(HTTP_REQUEST_PARAMETERS);
+        assertThat(infoValues).containsOnly(infoValues.entrySet().toArray(new Map.Entry[infoValues.entrySet().size()]));
+    }
+
+}


### PR DESCRIPTION
This PR fixes two issues:
1. We weren't logging exceptions or returning a 500 when exceptions were thrown while logging.
2. We weren't accounting for null values of request.getPathInfo()
