### PR TITLE
Bugfix logging

### DIFF
--- a/src/main/java/org/opentestsystem/delivery/logging/LoggingExceptionHandler.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/LoggingExceptionHandler.java
@@ -13,7 +13,6 @@ import static org.opentestsystem.delivery.logging.LoggingInterceptor.EVENT_INFO;
 import static org.opentestsystem.delivery.logging.LoggingInterceptor.LOGGER_NAME;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
-@EnableWebMvc
 @ControllerAdvice
 /**
  * Common exception handler for event logging.

--- a/src/main/java/org/opentestsystem/delivery/logging/RabbitConfiguration.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/RabbitConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -80,7 +81,7 @@ public class RabbitConfiguration {
   }
 
   @Bean
-  public ConfigRefreshListener configRefreshListener(final LoggingConfigRefresher loggingConfigRefresher, final ObjectMapper objectMapper) {
+  public ConfigRefreshListener configRefreshListener(final LoggingConfigRefresher loggingConfigRefresher, @Qualifier("integrationObjectMapper") final ObjectMapper objectMapper) {
     return new ConfigRefreshListener(loggingConfigRefresher, objectMapper);
   }
 


### PR DESCRIPTION
Enabling enhanced logging is done by using spring component scanning on the logging package.
The logging package used the EnableWebMVC annotation.  This conflicted with apps that declared the annotation-driven xml element.

Also see:
http://stackoverflow.com/questions/28150435/can-not-understand-difference-in-behavior-between-enablewebmvc-and-annotatio