### PR TITLE
Fix using rabbitmq address list

### DIFF
--- a/src/main/java/org/opentestsystem/delivery/logging/RabbitConfiguration.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/RabbitConfiguration.java
@@ -24,7 +24,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 @Configuration
 public class RabbitConfiguration {
 
-  @Value("${rabbitmq.addresses}")
+  @Value("${rabbitmq.addresses:}")
   private String addresses;
 
   @Value("${rabbitmq.host:localhost}")


### PR DESCRIPTION
Rabbitmq configuration can use either a list of addresses or a single host.

If the new rabbitmq.addresses property does not exist, fall back to using the existing rabbitmq.host property.