### PR TITLE
Feature/remove event from console

### DIFF
--- a/src/main/java/org/opentestsystem/delivery/logging/EventLogger.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventLogger.java
@@ -56,10 +56,10 @@ public interface EventLogger {
    * @param message    an optional free-format message string to add to the log entry
    * @param data       optional searchable event data to add to the recorded event
    */
-   void info(final String app, final String logEvent, final String checkpoint,
-             final String message, final Map<EventData, Object> data);
+   void trace(final String app, final String logEvent, final String checkpoint,
+              final String message, final Map<EventData, Object> data);
 
-   void info(final EventInfo eventData);
+   void trace(final EventInfo eventData);
 
   /**
    * Log event errors to centralized logging.

--- a/src/main/java/org/opentestsystem/delivery/logging/EventLoggerBase.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventLoggerBase.java
@@ -89,7 +89,7 @@ public abstract class EventLoggerBase implements EventLogger {
 
   private void log(final String event, final Map<String, Object> fields) {
     try {
-      logger.info(marker, format("EVENT:%s JSON:({\"event_data\": %s})", event, writer.writeValueAsString(fields)));
+      logger.trace(marker, format("EVENT:%s JSON:({\"event_data\": %s})", event, writer.writeValueAsString(fields)));
     } catch (Exception e) {
       logger.warn(marker, format("exception occurred while logging event: %s", event), e);
     }

--- a/src/main/java/org/opentestsystem/delivery/logging/EventLoggerBase.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/EventLoggerBase.java
@@ -51,8 +51,8 @@ public abstract class EventLoggerBase implements EventLogger {
    * @param message    an optional free-format message string to add to the log entry
    * @param data       optional searchable event data to add to the recorded event
    */
-  public void info(final String app, final String logEvent, final String checkpoint,
-                   final String message, final Map<EventData, Object> data) {
+  public void trace(final String app, final String logEvent, final String checkpoint,
+                    final String message, final Map<EventData, Object> data) {
     log(formatMessage(logEvent, message), getFieldMap(app, logEvent, checkpoint, data));
   }
 
@@ -62,8 +62,8 @@ public abstract class EventLoggerBase implements EventLogger {
    */
   protected abstract String getApp();
 
-  public void info(final EventInfo eventInfo) {
-    info(getApp(), eventInfo.event(), eventInfo.checkpoint().or(""), eventInfo.message().or(""), eventInfo.data());
+  public void trace(final EventInfo eventInfo) {
+    trace(getApp(), eventInfo.event(), eventInfo.checkpoint().or(""), eventInfo.message().or(""), eventInfo.data());
   }
 
   public void error(final EventInfo eventInfo, final Exception e) {

--- a/src/main/java/org/opentestsystem/delivery/logging/LoggingInterceptor.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/LoggingInterceptor.java
@@ -36,7 +36,7 @@ public class LoggingInterceptor extends HandlerInterceptorAdapter {
     final EventParser parser = factory.get(request);
     final Optional<EventInfo> eventInfo = parser.parsePreHandle(request, handler, logger);
     if (eventInfo.isPresent()) {
-      logger.info(eventInfo.get().withCheckpoint(ENTER.name()));
+      logger.trace(eventInfo.get().withCheckpoint(ENTER.name()));
       request.setAttribute(EVENT_INFO, eventInfo.get());
     }
     return true;
@@ -48,7 +48,7 @@ public class LoggingInterceptor extends HandlerInterceptorAdapter {
     final EventParser parser = factory.get(request);
     final Optional<EventInfo> eventInfo = parser.parsePostHandle(request, response, handler, logger);
     if (eventInfo.isPresent()) {
-      logger.info(eventInfo.get().withCheckpoint(EXIT.name()));
+      logger.trace(eventInfo.get().withCheckpoint(EXIT.name()));
     }
   }
 }

--- a/src/main/resources/logback-included-common-config.xml
+++ b/src/main/resources/logback-included-common-config.xml
@@ -34,6 +34,10 @@
                 <!-- encoder is required -->
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
             </appender>
+            <!-- send trace event logs to LOGSTASH but not to CONSOLE-->
+            <logger name="org.opentestsystem.delivery.logging" level="trace" additive="false">
+                <appender-ref ref="LOGSTASH"/>
+            </logger>
         </then>
     </if>
 

--- a/src/main/resources/logback-included-common-config.xml
+++ b/src/main/resources/logback-included-common-config.xml
@@ -34,7 +34,7 @@
                 <!-- encoder is required -->
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
             </appender>
-            <!-- send trace event logs to LOGSTASH but not to CONSOLE-->
+            <!-- send trace event logs to LOGSTASH but not to CONSOLE by default -->
             <logger name="org.opentestsystem.delivery.logging" level="trace" additive="false">
                 <appender-ref ref="LOGSTASH"/>
             </logger>


### PR DESCRIPTION
Send event trace logs to logstash, but not the console by default.

Move event logs from info level to trace. Sending EventLogger trace entries to logstash.
Console logs remain at info level.