### PR TITLE
Fixes spring slueth malformed id exception

### DIFF
--- a/src/main/java/org/opentestsystem/delivery/logging/LoggingInterceptor.java
+++ b/src/main/java/org/opentestsystem/delivery/logging/LoggingInterceptor.java
@@ -43,7 +43,7 @@ public class LoggingInterceptor extends HandlerInterceptorAdapter {
     if (eventInfoOptional.isPresent()) {
       final EventInfo eventInfo = eventInfoOptional.get();
       UUID httpRequestUUID = Optional.fromNullable((UUID)logger.getField(HTTP_REQUEST_UUID.name())).or(UUID.randomUUID());
-      MDC.put(HTTP_REQUEST_UUID_NAME, httpRequestUUID.toString());
+      MDC.put(HTTP_REQUEST_UUID_NAME, httpRequestUUID.toString().replace("-", ""));
 
       logger.trace(eventInfo.withCheckpoint(ENTER.name()));
       request.setAttribute(EVENT_INFO, eventInfo);


### PR DESCRIPTION
Fixes java.lang.IllegalArgumentException: Malformed id:
org.springframework.cloud.sleuth.Span.hexToId(Span.java:575)